### PR TITLE
Strip '/' from influxdb URI path, it cause error for database name

### DIFF
--- a/metrics-reporter-influxdb/src/main/java/org/graylog/plugins/metrics/influxdb/providers/InfluxDbSenderProvider.java
+++ b/metrics-reporter-influxdb/src/main/java/org/graylog/plugins/metrics/influxdb/providers/InfluxDbSenderProvider.java
@@ -52,7 +52,7 @@ public class InfluxDbSenderProvider implements Provider<InfluxDbSender> {
                             protocol,
                             uri.getHost(),
                             uri.getPort(),
-                            uri.getPath(),
+                            uri.getPath().replaceFirst("^/", ""),
                             uri.getUserInfo(),
                             configuration.getTimePrecision(),
                             Ints.saturatedCast(configuration.getConnectTimeout().toMilliseconds()),


### PR DESCRIPTION
getPath() from influxdb URI doesn't strip out "/" prefix from the database name and is causing error 404 when graylog tries to write data to influxdb.
Fixed this by strips the "/" prefix from database name.
