### PR TITLE
Update package names to reflect artifactId

### DIFF
--- a/metrics-reporter-cassandra/src/deb/control/control
+++ b/metrics-reporter-cassandra/src/deb/control/control
@@ -1,4 +1,4 @@
-Package: [[name]]
+Package: [[artifactId]]
 Version: [[version]]
 Architecture: all
 Maintainer: Graylog, Inc. <hello@graylog.com>

--- a/metrics-reporter-console/src/deb/control/control
+++ b/metrics-reporter-console/src/deb/control/control
@@ -1,4 +1,4 @@
-Package: [[name]]
+Package: [[artifactId]]
 Version: [[version]]
 Architecture: all
 Maintainer: Graylog, Inc. <hello@graylog.com>

--- a/metrics-reporter-csv/src/deb/control/control
+++ b/metrics-reporter-csv/src/deb/control/control
@@ -1,4 +1,4 @@
-Package: [[name]]
+Package: [[artifactId]]
 Version: [[version]]
 Architecture: all
 Maintainer: Graylog, Inc. <hello@graylog.com>

--- a/metrics-reporter-datadog/src/deb/control/control
+++ b/metrics-reporter-datadog/src/deb/control/control
@@ -1,4 +1,4 @@
-Package: [[name]]
+Package: [[artifactId]]
 Version: [[version]]
 Architecture: all
 Maintainer: Graylog, Inc. <hello@graylog.com>

--- a/metrics-reporter-elasticsearch/src/deb/control/control
+++ b/metrics-reporter-elasticsearch/src/deb/control/control
@@ -1,4 +1,4 @@
-Package: [[name]]
+Package: [[artifactId]]
 Version: [[version]]
 Architecture: all
 Maintainer: Graylog, Inc. <hello@graylog.com>

--- a/metrics-reporter-ganglia/src/deb/control/control
+++ b/metrics-reporter-ganglia/src/deb/control/control
@@ -1,4 +1,4 @@
-Package: [[name]]
+Package: [[artifactId]]
 Version: [[version]]
 Architecture: all
 Maintainer: Graylog, Inc. <hello@graylog.com>

--- a/metrics-reporter-gelf/src/deb/control/control
+++ b/metrics-reporter-gelf/src/deb/control/control
@@ -1,4 +1,4 @@
-Package: [[name]]
+Package: [[artifactId]]
 Version: [[version]]
 Architecture: all
 Maintainer: Graylog, Inc. <hello@graylog.com>

--- a/metrics-reporter-graphite/src/deb/control/control
+++ b/metrics-reporter-graphite/src/deb/control/control
@@ -1,4 +1,4 @@
-Package: [[name]]
+Package: [[artifactId]]
 Version: [[version]]
 Architecture: all
 Maintainer: Graylog, Inc. <hello@graylog.com>

--- a/metrics-reporter-influxdb/src/deb/control/control
+++ b/metrics-reporter-influxdb/src/deb/control/control
@@ -1,4 +1,4 @@
-Package: [[name]]
+Package: [[artifactId]]
 Version: [[version]]
 Architecture: all
 Maintainer: Graylog, Inc. <hello@graylog.com>

--- a/metrics-reporter-jmx/src/deb/control/control
+++ b/metrics-reporter-jmx/src/deb/control/control
@@ -1,4 +1,4 @@
-Package: [[name]]
+Package: [[artifactId]]
 Version: [[version]]
 Architecture: all
 Maintainer: Graylog, Inc. <hello@graylog.com>

--- a/metrics-reporter-librato/src/deb/control/control
+++ b/metrics-reporter-librato/src/deb/control/control
@@ -1,4 +1,4 @@
-Package: [[name]]
+Package: [[artifactId]]
 Version: [[version]]
 Architecture: all
 Maintainer: Graylog, Inc. <hello@graylog.com>

--- a/metrics-reporter-mongodb/src/deb/control/control
+++ b/metrics-reporter-mongodb/src/deb/control/control
@@ -1,4 +1,4 @@
-Package: [[name]]
+Package: [[artifactId]]
 Version: [[version]]
 Architecture: all
 Maintainer: Graylog, Inc. <hello@graylog.com>

--- a/metrics-reporter-prometheus/src/deb/control/control
+++ b/metrics-reporter-prometheus/src/deb/control/control
@@ -1,4 +1,4 @@
-Package: [[name]]
+Package: [[artifactId]]
 Version: [[version]]
 Architecture: all
 Maintainer: Graylog, Inc. <hello@graylog.com>

--- a/metrics-reporter-slf4j/src/deb/control/control
+++ b/metrics-reporter-slf4j/src/deb/control/control
@@ -1,4 +1,4 @@
-Package: [[name]]
+Package: [[artifactId]]
 Version: [[version]]
 Architecture: all
 Maintainer: Graylog, Inc. <hello@graylog.com>

--- a/metrics-reporter-statsd/src/deb/control/control
+++ b/metrics-reporter-statsd/src/deb/control/control
@@ -1,4 +1,4 @@
-Package: [[name]]
+Package: [[artifactId]]
 Version: [[version]]
 Architecture: all
 Maintainer: Graylog, Inc. <hello@graylog.com>


### PR DESCRIPTION
When using `mvn jdeb:jdeb` I noticed that the deb files that were generated had the package name of the module itself (ie. using `apt-cache show` returns `Package: Graylog Metrics Graphite Reporter Plugin`) rather than the artifact name (`Package: metrics-reporter-graphite`). 

I think people expect to use `apt-get install metrics-reporter-graphite` rather than `apt-get install 'Graylog Metrics Graphite Reporter Plugin'` -- so this patch updates src/deb/control/control to use that instead.