### PR TITLE
New config flag to disable prometheus pushgateway

### DIFF
--- a/metrics-reporter-prometheus/README.md
+++ b/metrics-reporter-prometheus/README.md
@@ -25,7 +25,8 @@ scrape_configs:
 
 | Setting                              | Default          | Description                                                                                       |
 | ------------------------------------ | ---------------- | ------------------------------------------------------------------------------------------------- |
-| `metrics_prometheus_enabled`         | `false`          | Whether to push the metrics to a [Prometheus Pushgateway].                                        |
+| `metrics_prometheus_enabled`         | `false`          | Whether to expose prometheus metrics.                                        |
+| `metrics_prometheus_pushgateway_disabled`| `false`      | Whether to disable push metrics to a [Prometheus Pushgateway].                                        |
 | `metrics_prometheus_report_interval` | `15s`            | How often to report metrics to the [Prometheus Pushgateway].                                      |
 | `metrics_prometheus_address`         | `127.0.0.1:9091` | The network address of the [Prometheus Pushgateway].                                              |
 | `metrics_prometheus_job_name`        | `graylog`        | The job name used with the [Prometheus Pushgateway].                                              |

--- a/metrics-reporter-prometheus/src/main/java/org/graylog/plugins/metrics/prometheus/MetricsPrometheusReporterConfiguration.java
+++ b/metrics-reporter-prometheus/src/main/java/org/graylog/plugins/metrics/prometheus/MetricsPrometheusReporterConfiguration.java
@@ -31,6 +31,9 @@ public class MetricsPrometheusReporterConfiguration implements PluginConfigBean 
 
     @Parameter(PREFIX + "enabled")
     private boolean enabled = false;
+    
+    @Parameter(PREFIX + "pushgateway_disabled")
+    private boolean pushGatewayDisabled = true;
 
     @Parameter(value = PREFIX + "report_interval", required = true, validator = PositiveDurationValidator.class)
     private Duration reportInterval = Duration.seconds(15L);
@@ -46,6 +49,10 @@ public class MetricsPrometheusReporterConfiguration implements PluginConfigBean 
 
     public boolean isEnabled() {
         return enabled;
+    }
+    
+    public boolean isPushGatewayDisabled() {
+        return pushGatewayDisabled;
     }
 
     public Duration getReportInterval() {

--- a/metrics-reporter-prometheus/src/main/java/org/graylog/plugins/metrics/prometheus/PushGatewayPeriodical.java
+++ b/metrics-reporter-prometheus/src/main/java/org/graylog/plugins/metrics/prometheus/PushGatewayPeriodical.java
@@ -47,10 +47,12 @@ public class PushGatewayPeriodical extends Periodical {
     @Override
     public void doRun() {
         try {
-            pushGateway.push(
+        	if (configuration.isPushGatewayDisabled()) {
+        		pushGateway.push(
                     collectorRegistry,
                     configuration.getJobName(),
                     configuration.getGroupingKey());
+        	}
         } catch (IOException e) {
             LOG.error("Error while sending metrics to Prometheus Pushgateway", e);
         }


### PR DESCRIPTION
The current prometheus plugin always initialise pushing metrics to a prometheus server. I prefer to scrape/pull my prometheus endpoints rather than pushing. 
Besides that, if the pushgateway is not configured, this plugin make the logs polluted. 

To avoid this behaviour, I made this PR to pass a flag to disable the pushgateway. 

## Flag 
```
metrics_prometheus_pushgateway_disabled: true
```

## Polluted logs
```
[graylog-master-2794354343-pjl6t] 2017-02-23 15:49:22,568 ERROR: org.graylog.plugins.metrics.prometheus.PushGatewayPeriodical - Error while sending metrics to Prometheus Pushgateway
[graylog-master-2794354343-pjl6t] java.net.ConnectException: Connection refused (Connection refused)
[graylog-master-2794354343-pjl6t] at java.net.PlainSocketImpl.socketConnect(Native Method) ~[?:1.8.0_111]
[graylog-master-2794354343-pjl6t] at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:350) ~[?:1.8.0_111]
[graylog-master-2794354343-pjl6t] at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:206) ~[?:1.8.0_111]
[graylog-master-2794354343-pjl6t] at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:188) ~[?:1.8.0_111]
[graylog-master-2794354343-pjl6t] at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:392) ~[?:1.8.0_111]
[graylog-master-2794354343-pjl6t] at java.net.Socket.connect(Socket.java:589) ~[?:1.8.0_111]
[graylog-master-2794354343-pjl6t] at sun.net.NetworkClient.doConnect(NetworkClient.java:175) ~[?:1.8.0_111]
[graylog-master-2794354343-pjl6t] at sun.net.www.http.HttpClient.openServer(HttpClient.java:432) ~[?:1.8.0_111]
[graylog-master-2794354343-pjl6t] at sun.net.www.http.HttpClient.openServer(HttpClient.java:527) ~[?:1.8.0_111]
[graylog-master-2794354343-pjl6t] at sun.net.www.http.HttpClient.<init>(HttpClient.java:211) ~[?:1.8.0_111]
[graylog-master-2794354343-pjl6t] at sun.net.www.http.HttpClient.New(HttpClient.java:308) ~[?:1.8.0_111]
[graylog-master-2794354343-pjl6t] at sun.net.www.http.HttpClient.New(HttpClient.java:326) ~[?:1.8.0_111]
[graylog-master-2794354343-pjl6t] at sun.net.www.protocol.http.HttpURLConnection.getNewHttpClient(HttpURLConnection.java:1202) ~[?:1.8.0_111]
[graylog-master-2794354343-pjl6t] at sun.net.www.protocol.http.HttpURLConnection.plainConnect0(HttpURLConnection.java:1138) ~[?:1.8.0_111]
[graylog-master-2794354343-pjl6t] at sun.net.www.protocol.http.HttpURLConnection.plainConnect(HttpURLConnection.java:1032) ~[?:1.8.0_111]
[graylog-master-2794354343-pjl6t] at sun.net.www.protocol.http.HttpURLConnection.connect(HttpURLConnection.java:966) ~[?:1.8.0_111]
[graylog-master-2794354343-pjl6t] at io.prometheus.client.exporter.PushGateway.doRequest(PushGateway.java:253) ~[metrics-reporter-prometheus-1.4.0.jar:?]
[graylog-master-2794354343-pjl6t] at io.prometheus.client.exporter.PushGateway.push(PushGateway.java:96) ~[metrics-reporter-prometheus-1.4.0.jar:?]
[graylog-master-2794354343-pjl6t] at org.graylog.plugins.metrics.prometheus.PushGatewayPeriodical.doRun(PushGatewayPeriodical.java:50) [metrics-reporter-prometheus-1.4.0.jar:?]
[graylog-master-2794354343-pjl6t] at org.graylog2.plugin.periodical.Periodical.run(Periodical.java:77) [graylog.jar:?]
[graylog-master-2794354343-pjl6t] at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [?:1.8.0_111]
[graylog-master-2794354343-pjl6t] at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308) [?:1.8.0_111]
[graylog-master-2794354343-pjl6t] at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180) [?:1.8.0_111]
[graylog-master-2794354343-pjl6t] at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294) [?:1.8.0_111]
[graylog-master-2794354343-pjl6t] at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [?:1.8.0_111]
[graylog-master-2794354343-pjl6t] at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [?:1.8.0_111]
[graylog-master-2794354343-pjl6t] at java.lang.Thread.run(Thread.java:745) [?:1.8.0_111]

```