### PR TITLE
allow Graphite instance to properly handle dns based hostnames

### DIFF
--- a/metrics-reporter-graphite/src/main/java/org/graylog/plugins/metrics/graphite/MetricsGraphiteReporterConfiguration.java
+++ b/metrics-reporter-graphite/src/main/java/org/graylog/plugins/metrics/graphite/MetricsGraphiteReporterConfiguration.java
@@ -20,11 +20,11 @@ import com.github.joschi.jadconfig.Parameter;
 import com.github.joschi.jadconfig.util.Duration;
 import com.github.joschi.jadconfig.validators.PositiveDurationValidator;
 import com.github.joschi.jadconfig.validators.PositiveIntegerValidator;
+import com.google.common.net.HostAndPort;
 import org.graylog.plugins.metrics.core.jadconfig.PatternListConverter;
 import org.graylog.plugins.metrics.graphite.converters.GraphiteProtocolConverter;
 import org.graylog2.plugin.PluginConfigBean;
 
-import java.net.InetSocketAddress;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
@@ -39,7 +39,7 @@ public class MetricsGraphiteReporterConfiguration implements PluginConfigBean {
     private boolean enabled = false;
 
     @Parameter(value = PREFIX + "address", required = true)
-    private InetSocketAddress address = new InetSocketAddress("127.0.0.1", 2003);
+    private HostAndPort address = HostAndPort.fromParts("127.0.0.1", 2003);
 
     @Parameter(value = PREFIX + "charset", required = true)
     private Charset charset = StandardCharsets.UTF_8;
@@ -73,7 +73,7 @@ public class MetricsGraphiteReporterConfiguration implements PluginConfigBean {
         return reportInterval;
     }
 
-    public InetSocketAddress getAddress() {
+    public HostAndPort getAddress() {
         return address;
     }
 

--- a/metrics-reporter-graphite/src/main/java/org/graylog/plugins/metrics/graphite/providers/GraphiteSenderProvider.java
+++ b/metrics-reporter-graphite/src/main/java/org/graylog/plugins/metrics/graphite/providers/GraphiteSenderProvider.java
@@ -20,6 +20,7 @@ import com.codahale.metrics.graphite.Graphite;
 import com.codahale.metrics.graphite.GraphiteSender;
 import com.codahale.metrics.graphite.GraphiteUDP;
 import com.codahale.metrics.graphite.PickledGraphite;
+import com.google.common.net.HostAndPort;
 import org.graylog.plugins.metrics.graphite.MetricsGraphiteReporterConfiguration;
 
 import javax.inject.Inject;
@@ -38,17 +39,22 @@ public class GraphiteSenderProvider implements Provider<GraphiteSender> {
 
     @Override
     public GraphiteSender get() {
+        HostAndPort hostAndPort = configuration.getAddress();
+        String host = hostAndPort.getHostText();
+        int port = hostAndPort.getPortOrDefault(2003);
+
         switch (configuration.getProtocol()) {
             case PICKLE:
                 return new PickledGraphite(
-                        configuration.getAddress(),
+                        host,
+                        port,
                         SocketFactory.getDefault(),
                         configuration.getCharset(),
                         configuration.getPickleBatchSize());
             case TCP:
-                return new Graphite(configuration.getAddress(), SocketFactory.getDefault(), configuration.getCharset());
+                return new Graphite(host, port, SocketFactory.getDefault(), configuration.getCharset());
             case UDP:
-                return new GraphiteUDP(configuration.getAddress());
+                return new GraphiteUDP(host, port);
             default:
                 throw new IllegalArgumentException("Unknown Graphite protocol \"" + configuration.getProtocol() + "\"");
         }


### PR DESCRIPTION
We have graphite tcp listeners behind an ELB in AWS (not that is is specific to AWS, just showing our scenario). When the ELB ips change, we start to not receive metrics from Graylog. This change basically just uses the proper Graphite constructor to handle dns in the graphite implementation. More info here https://github.com/dropwizard/metrics/issues/606.

As a side note, it appears at first glance that the Gelf metric reporter may suffer from this issue too. But we don't use that, so I cannot confirm that.