### PR TITLE
Export saner metrics names to prometheus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ out/
 
 # OS X
 .DS_Store
+.factorypath
+.vscode/settings.json

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ out/
 .DS_Store
 .factorypath
 .vscode/settings.json
+.envrc

--- a/metrics-reporter-prometheus/README.md
+++ b/metrics-reporter-prometheus/README.md
@@ -14,7 +14,7 @@ For streams and stream rules additional information is provided as labels:
 * `stream-title`: title of stream (stream and stream rule)
 * `rule-type`: Type of stream rule, e.g. `regexp`
 * `stream-id`: related stream id for stream rule
-* `index-set-id`: ID ofrelated index set for stream and stream rule
+* `index-set-id`: ID of related index set for stream and stream rule
 
 ## Pulling metrics
 

--- a/metrics-reporter-prometheus/README.md
+++ b/metrics-reporter-prometheus/README.md
@@ -1,5 +1,21 @@
 # metrics-reporter-prometheus
 
+This plugin exposes metrics to be scrapeable by prometheus.
+
+It primarily converts the internally used Dropbox metrics one to one with a few
+notable exceptions:
+
+For any metric that has an ID embedded in its metric name, the id is removed
+from the metric name and added as label `id` to prevent unnecessary
+proliferation of metrics and make them easier to compare and/or aggregate.
+
+For streams and stream rules additional information is provided as labels:
+
+* `stream-title`: title of stream (stream and stream rule)
+* `rule-type`: Type of stream rule, e.g. `regexp`
+* `stream-id`: rleated stream id for stream rule
+* `index-set-id`: ID ofrelated index set for stream and stream rule
+
 ## Pulling metrics
 
 The Prometheus metrics endpoint is available at `http://graylog.example.com:9000/api/plugins/org.graylog.plugins.metrics.prometheus/metrics`.

--- a/metrics-reporter-prometheus/README.md
+++ b/metrics-reporter-prometheus/README.md
@@ -13,7 +13,7 @@ For streams and stream rules additional information is provided as labels:
 
 * `stream-title`: title of stream (stream and stream rule)
 * `rule-type`: Type of stream rule, e.g. `regexp`
-* `stream-id`: rleated stream id for stream rule
+* `stream-id`: related stream id for stream rule
 * `index-set-id`: ID ofrelated index set for stream and stream rule
 
 ## Pulling metrics

--- a/metrics-reporter-prometheus/pom.xml
+++ b/metrics-reporter-prometheus/pom.xml
@@ -18,7 +18,7 @@
     <description>Plugin for reporting internal Graylog metrics to Prometheus.</description>
 
     <properties>
-        <simpleclient.version>0.3.0</simpleclient.version>
+        <simpleclient.version>0.6.0</simpleclient.version>
     </properties>
 
     <dependencies>

--- a/metrics-reporter-prometheus/src/main/java/org/graylog/plugins/metrics/prometheus/DropwizardSampleBuilder.java
+++ b/metrics-reporter-prometheus/src/main/java/org/graylog/plugins/metrics/prometheus/DropwizardSampleBuilder.java
@@ -1,0 +1,132 @@
+/**
+ * This file is part of Graylog Metrics Prometheus Reporter Plugin.
+ *
+ * Graylog Metrics Prometheus Reporter Plugin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Metrics Prometheus Reporter Plugin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Metrics Prometheus Reporter Plugin.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.metrics.prometheus;
+
+import org.graylog2.database.NotFoundException;
+import org.graylog2.plugin.streams.Stream;
+import org.graylog2.plugin.streams.StreamRule;
+import org.graylog2.streams.StreamRuleService;
+import org.graylog2.streams.StreamService;
+
+import io.prometheus.client.Collector;
+import io.prometheus.client.Collector.MetricFamilySamples.Sample;
+import io.prometheus.client.dropwizard.samplebuilder.DefaultSampleBuilder;
+
+import javax.inject.Inject;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.MatchResult;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.Collections;
+
+
+public class DropwizardSampleBuilder extends DefaultSampleBuilder {
+
+    private static final String ID_METRIC_PATTERN = "(.*?)\\.([0-9a-f-]{8,})\\.(.*)";
+    private final StreamService streamService;
+    private final StreamRuleService streamRuleService;
+    private final Pattern idPattern;
+
+    @Inject
+    public DropwizardSampleBuilder(StreamService streamService,StreamRuleService streamRuleService) {
+        this.streamService = requireNonNull(streamService);
+        this.streamRuleService = requireNonNull(streamRuleService);
+        this.idPattern =         Pattern.compile(ID_METRIC_PATTERN);
+    }
+
+    @Override
+    public Sample createSample(
+        String dropwizardName,
+        String nameSuffix,
+        List<String> additionalLabelNames,
+        List<String> additionalLabelValues,
+        double value
+    ) {
+
+        final List<String> labelNames = additionalLabelNames == null ? Collections.<String>emptyList() : additionalLabelNames;
+        final List<String> labelValues = additionalLabelValues == null ? Collections.<String>emptyList() : additionalLabelValues;
+
+        Matcher m = idPattern.matcher(dropwizardName);
+
+        if (!m.matches()) {
+            return new Collector.MetricFamilySamples.Sample(
+                Collector.sanitizeMetricName(dropwizardName),
+                new ArrayList<String>(labelNames),
+                new ArrayList<String>(labelValues),
+                value
+            );
+        }
+
+        MatchResult result = m.toMatchResult();
+        String metricName = String.join(":", Arrays.asList(result.group(1), result.group(2)));
+        String id = result.group(2);
+        labelNames.add("id");
+        labelValues.add(id);
+
+        if (dropwizardName.contains(".StreamRule.")) {
+            try {
+                StreamRule rule = streamRuleService.load(id);
+                String ruleType =  rule.getType().toString();
+                labelNames.add("id");
+                labelValues.add(id);
+                labelNames.add("rule-type");
+                labelValues.add(ruleType);
+
+                try {
+                    Stream stream = streamService.load(rule.getStreamId());
+                    labelNames.add("stream-id");
+                    labelValues.add(stream.getId());
+                    labelNames.add("stream-title");
+                    labelValues.add(stream.getTitle());
+                    labelNames.add("index-set-id");
+                    labelValues.add(stream.getIndexSetId());
+                } catch (NotFoundException nfe) {
+                    // we'll have to live with less information I guess
+                }
+
+            } catch (NotFoundException nfe) {
+                labelNames.add("rule-type");
+                labelValues.add("unknown");
+            }
+
+        }
+
+        if (dropwizardName.contains(".Stream.")) {
+            try {
+                Stream s = streamService.load(id);
+                additionalLabelNames.add("stream-title");
+                additionalLabelValues.add(s.getTitle());
+                labelNames.add("index-set-id");
+                labelValues.add(s.getIndexSetId());
+            } catch (NotFoundException e) {
+                // we'll have to live with less information I guess
+            }
+        }
+
+       return new Collector.MetricFamilySamples.Sample(
+                Collector.sanitizeMetricName(metricName),
+                new ArrayList<String>(labelNames),
+                new ArrayList<String>(labelValues),
+                value
+        );
+    }
+}

--- a/metrics-reporter-prometheus/src/main/java/org/graylog/plugins/metrics/prometheus/DropwizardSampleBuilder.java
+++ b/metrics-reporter-prometheus/src/main/java/org/graylog/plugins/metrics/prometheus/DropwizardSampleBuilder.java
@@ -29,6 +29,7 @@ import io.prometheus.client.dropwizard.samplebuilder.DefaultSampleBuilder;
 import javax.inject.Inject;
 
 import static java.util.Objects.requireNonNull;
+import static io.prometheus.client.Collector.sanitizeMetricName;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -67,7 +68,7 @@ public class DropwizardSampleBuilder extends DefaultSampleBuilder {
 
         if (!m.matches()) {
             return new Collector.MetricFamilySamples.Sample(
-                Collector.sanitizeMetricName(dropwizardName),
+                sanitizeMetricName(dropwizardName),
                 new ArrayList<String>(labelNames),
                 new ArrayList<String>(labelValues),
                 value
@@ -75,10 +76,10 @@ public class DropwizardSampleBuilder extends DefaultSampleBuilder {
         }
 
         MatchResult result = m.toMatchResult();
-        String metricName = String.join(":", Arrays.asList(
-            Collector.sanitizeMetricName(result.group(1)),
-            Collector.sanitizeMetricName(result.group(3)))
-        );
+        String metricName = sanitizeMetricName(String.join("_", Arrays.asList(
+            result.group(1),
+            result.group(3))
+        ));
 
         String id = result.group(2);
         labelNames.add("id");

--- a/metrics-reporter-prometheus/src/main/java/org/graylog/plugins/metrics/prometheus/DropwizardSampleBuilder.java
+++ b/metrics-reporter-prometheus/src/main/java/org/graylog/plugins/metrics/prometheus/DropwizardSampleBuilder.java
@@ -36,8 +36,6 @@ import java.util.List;
 import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.Collections;
-
 
 public class DropwizardSampleBuilder extends DefaultSampleBuilder {
 

--- a/metrics-reporter-prometheus/src/main/java/org/graylog/plugins/metrics/prometheus/DropwizardSampleBuilder.java
+++ b/metrics-reporter-prometheus/src/main/java/org/graylog/plugins/metrics/prometheus/DropwizardSampleBuilder.java
@@ -103,6 +103,8 @@ public class DropwizardSampleBuilder extends DefaultSampleBuilder {
                 Stream s = streamService.load(id);
                 labelNames.add("stream_title");
                 labelValues.add(s.getTitle());
+                labelNames.add("index_set_id");
+                labelValues.add(s.getIndexSetId());
             } catch (NotFoundException e) {
                 // we'll have to live with less information I guess
             }

--- a/metrics-reporter-prometheus/src/main/java/org/graylog/plugins/metrics/prometheus/DropwizardSampleBuilder.java
+++ b/metrics-reporter-prometheus/src/main/java/org/graylog/plugins/metrics/prometheus/DropwizardSampleBuilder.java
@@ -86,10 +86,15 @@ public class DropwizardSampleBuilder extends DefaultSampleBuilder {
         labelValues.add(id);
 
         if (dropwizardName.contains(".ast.Rule.")) {
-            labelNames.add("pipeline-id");
-            labelValues.add(result.group(3));
-            labelNames.add("stage");
-            labelValues.add(result.group(4));
+            if (result.group(3) != null) {
+                labelNames.add("pipeline-id");
+                labelValues.add(result.group(3));
+            }
+
+            if (result.group(4) != null) {
+                labelNames.add("stage");
+                labelValues.add(result.group(4));
+            }
         }
 
         if (dropwizardName.contains(".StreamRule.")) {

--- a/metrics-reporter-prometheus/src/main/java/org/graylog/plugins/metrics/prometheus/DropwizardSampleBuilder.java
+++ b/metrics-reporter-prometheus/src/main/java/org/graylog/plugins/metrics/prometheus/DropwizardSampleBuilder.java
@@ -87,7 +87,7 @@ public class DropwizardSampleBuilder extends DefaultSampleBuilder {
 
         if (dropwizardName.contains(".ast.Rule.")) {
             if (result.group(3) != null) {
-                labelNames.add("pipeline-id");
+                labelNames.add("pipeline_id");
                 labelValues.add(result.group(3));
             }
 
@@ -101,24 +101,24 @@ public class DropwizardSampleBuilder extends DefaultSampleBuilder {
             try {
                 StreamRule rule = streamRuleService.load(id);
                 String ruleType =  rule.getType().toString();
-                labelNames.add("rule-type");
+                labelNames.add("rule_type");
                 labelValues.add(ruleType);
                 String streamId = rule.getStreamId();
-                labelNames.add("stream-id");
+                labelNames.add("stream_id");
                 labelValues.add(streamId);
 
                 try {
                     Stream stream = streamService.load(streamId);
-                    labelNames.add("stream-title");
+                    labelNames.add("stream_title");
                     labelValues.add(stream.getTitle());
-                    labelNames.add("index-set-id");
+                    labelNames.add("index_set_id");
                     labelValues.add(stream.getIndexSetId());
                 } catch (NotFoundException nfe) {
                     // we'll have to live with less information I guess
                 }
 
             } catch (NotFoundException nfe) {
-                labelNames.add("rule-type");
+                labelNames.add("rule_type");
                 labelValues.add("unknown");
             }
 
@@ -127,9 +127,9 @@ public class DropwizardSampleBuilder extends DefaultSampleBuilder {
         if (dropwizardName.contains(".Stream.")) {
             try {
                 Stream s = streamService.load(id);
-                labelNames.add("stream-title");
+                labelNames.add("stream_title");
                 labelValues.add(s.getTitle());
-                labelNames.add("index-set-id");
+                labelNames.add("index_set_id");
                 labelValues.add(s.getIndexSetId());
             } catch (NotFoundException e) {
                 // we'll have to live with less information I guess

--- a/metrics-reporter-prometheus/src/main/java/org/graylog/plugins/metrics/prometheus/MetricsPrometheusReporterModule.java
+++ b/metrics-reporter-prometheus/src/main/java/org/graylog/plugins/metrics/prometheus/MetricsPrometheusReporterModule.java
@@ -21,6 +21,7 @@ import io.prometheus.client.dropwizard.DropwizardExports;
 import io.prometheus.client.exporter.PushGateway;
 import org.graylog.plugins.metrics.prometheus.providers.CollectorRegistryProvider;
 import org.graylog.plugins.metrics.prometheus.providers.DropwizardExportsProvider;
+import org.graylog.plugins.metrics.prometheus.providers.DropwizardSampleBuilderProvider;
 import org.graylog.plugins.metrics.prometheus.providers.PushGatewayProvider;
 import org.graylog.plugins.metrics.prometheus.rest.MetricsResource;
 import org.graylog2.plugin.PluginConfigBean;
@@ -39,6 +40,7 @@ public class MetricsPrometheusReporterModule extends PluginModule {
     protected void configure() {
         addConfigBeans();
 
+        bind(DropwizardSampleBuilder.class).toProvider(DropwizardSampleBuilderProvider.class);
         bind(DropwizardExports.class).toProvider(DropwizardExportsProvider.class);
         bind(CollectorRegistry.class).toProvider(CollectorRegistryProvider.class);
         bind(PushGateway.class).toProvider(PushGatewayProvider.class);

--- a/metrics-reporter-prometheus/src/main/java/org/graylog/plugins/metrics/prometheus/providers/DropwizardSampleBuilderProvider.java
+++ b/metrics-reporter-prometheus/src/main/java/org/graylog/plugins/metrics/prometheus/providers/DropwizardSampleBuilderProvider.java
@@ -16,16 +16,9 @@
  */
 package org.graylog.plugins.metrics.prometheus.providers;
 
-import com.codahale.metrics.MetricRegistry;
-
-import org.graylog2.database.NotFoundException;
-import org.graylog2.plugin.streams.Stream;
 import org.graylog2.streams.StreamRuleService;
 import org.graylog2.streams.StreamService;
 
-import io.prometheus.client.Collector;
-import io.prometheus.client.Collector.MetricFamilySamples.Sample;
-import io.prometheus.client.dropwizard.DropwizardExports;
 import org.graylog.plugins.metrics.prometheus.DropwizardSampleBuilder;
 
 import javax.inject.Inject;
@@ -33,24 +26,19 @@ import javax.inject.Provider;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Collections;
 
-public class DropwizardExportsProvider implements Provider<DropwizardExports> {
-    private final MetricRegistry metricRegistry;
-    private final DropwizardSampleBuilder sampleBuilder;
-
+public class DropwizardSampleBuilderProvider implements Provider<DropwizardSampleBuilder> {
+    private final StreamService streamService;
+    private final StreamRuleService streamRuleService;
 
     @Inject
-    public DropwizardExportsProvider(MetricRegistry metricRegistry, DropwizardSampleBuilder sampleBuilder) {
-        this.metricRegistry = requireNonNull(metricRegistry);
-        this.sampleBuilder = sampleBuilder;
+    public DropwizardSampleBuilderProvider(StreamService streamService, StreamRuleService streamRuleService) {
+        this.streamRuleService = requireNonNull(streamRuleService);
+        this.streamService =  requireNonNull(streamService);
     }
 
     @Override
-    public DropwizardExports get() {
-        return new DropwizardExports(metricRegistry, sampleBuilder);
+    public DropwizardSampleBuilder get() {
+        return new DropwizardSampleBuilder(streamService, streamRuleService);
     }
 }
-

--- a/metrics-reporter-prometheus/src/test/java/org/graylog/plugins/metrics/prometheus/DropwizardSampleBuilderTest.java
+++ b/metrics-reporter-prometheus/src/test/java/org/graylog/plugins/metrics/prometheus/DropwizardSampleBuilderTest.java
@@ -27,7 +27,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Answers;
-import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
@@ -36,7 +35,8 @@ import java.util.Arrays;
 import static java.util.Collections.emptyList;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import static java.util.Arrays.*;
@@ -80,18 +80,19 @@ public class DropwizardSampleBuilderTest {
     //
     @Test
     public void doTestStreamStreamRule() throws Exception {
-        when(streamRuleService.load(Matchers.eq("5d35b414bf1062c54c8c8680"))).thenReturn(streamRule);
+        when(streamRuleService.load(eq("5d35b414bf1062c54c8c8680"))).thenReturn(streamRule);
         when(streamRule.getType()).thenReturn(StreamRuleType.PRESENCE);
 
-        when(streamService.load(Matchers.eq("5d356589bf1062c54c8c37ee"))).thenReturn(stream);
+        when(streamService.load(eq("5d356589bf1062c54c8c37ee"))).thenReturn(stream);
         when(stream.getTitle()).thenReturn("foo");
+        when(stream.getIndexSetId()).thenReturn("42");
 
         Sample s = sampleBuilder.createSample("org.graylog2.plugin.streams.Stream.5d356589bf1062c54c8c37ee.StreamRule.5d35b414bf1062c54c8c8680.executionTime", "", asList("quantile"), asList("0.5"), 1.0050000000000001E-6);
 
         assertEquals(new Sample(
            "org_graylog2_plugin_streams_Stream_StreamRule_executionTime",
-           Arrays.asList("quantile", "id", "stream_title", "stream_rule_id", "rule_type"),
-           Arrays.asList("0.5", "5d356589bf1062c54c8c37ee","foo","5d35b414bf1062c54c8c8680","PRESENCE"),
+           Arrays.asList("quantile", "id", "stream_title", "index_set_id","stream_rule_id", "rule_type"),
+           Arrays.asList("0.5", "5d356589bf1062c54c8c37ee","foo", "42", "5d35b414bf1062c54c8c8680","PRESENCE"),
            1.0050000000000001E-6
         ),s);
     }

--- a/metrics-reporter-prometheus/src/test/java/org/graylog/plugins/metrics/prometheus/DropwizardSampleBuilderTest.java
+++ b/metrics-reporter-prometheus/src/test/java/org/graylog/plugins/metrics/prometheus/DropwizardSampleBuilderTest.java
@@ -1,0 +1,141 @@
+/**
+ * This file is part of Graylog Metrics Prometheus Reporter Plugin.
+ *
+ * Graylog Metrics Prometheus Reporter Plugin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Metrics Prometheus Reporter Plugin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Metrics Prometheus Reporter Plugin.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.metrics.prometheus;
+
+import com.google.common.primitives.Ints;
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.Collector.MetricFamilySamples.Sample;
+import io.prometheus.client.exporter.PushGateway;
+
+import org.graylog2.plugin.streams.Stream;
+import org.graylog2.plugin.streams.StreamRule;
+import org.graylog2.plugin.streams.StreamRuleType;
+import org.graylog2.streams.StreamRuleService;
+import org.graylog2.streams.StreamService;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import static java.util.Collections.emptyList;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import static java.util.Arrays.*;
+
+public class DropwizardSampleBuilderTest {
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Mock(answer = Answers.RETURNS_MOCKS)
+    private StreamService streamService;
+    @Mock(answer = Answers.RETURNS_MOCKS)
+    private Stream stream;
+    @Mock(answer = Answers.RETURNS_MOCKS)
+    private StreamRule streamRule;
+
+    @Mock(answer = Answers.RETURNS_MOCKS)
+    private StreamRuleService streamRuleService;
+
+    private DropwizardSampleBuilder sampleBuilder;
+    @Before
+    public void setUp() throws Exception {
+        sampleBuilder = new DropwizardSampleBuilder(streamService,streamRuleService);
+    }
+
+    @Test
+    public void doTestStream() throws Exception {
+        when(streamService.load(anyString())).thenReturn(stream);
+        when(stream.getTitle()).thenReturn("foo");
+        when(stream.getIndexSetId()).thenReturn("42");
+
+        Sample s = sampleBuilder.createSample("org.graylog2.plugin.streams.Stream.58934a5e92493a6b7f383fea.incomingMessages.1-sec-rate", "", null, null, 2.0);
+
+        assertEquals(new Sample(
+           "org_graylog2_plugin_streams_Stream:incomingMessages_1_sec_rate",
+           Arrays.asList("id", "stream-title", "index-set-id"),
+           Arrays.asList("58934a5e92493a6b7f383fea","foo", "42"),
+           2.0
+        ),s);
+    }
+
+    @Test
+    public void doTestStreamRule() throws Exception {
+        when(streamRuleService.load(anyString())).thenReturn(streamRule);
+        when(streamRule.getStreamId()).thenReturn("x");
+        when(streamRule.getType()).thenReturn(StreamRuleType.PRESENCE);
+
+        when(streamService.load("x")).thenReturn(stream);
+        when(stream.getTitle()).thenReturn("foo");
+        when(stream.getIndexSetId()).thenReturn("42");
+
+        Sample s = sampleBuilder.createSample("org.graylog2.plugin.streams.StreamRule.58934a5e92493a6b7f384059.executionTime", "", asList("quantile"), asList("0.5"), 1.0050000000000001E-6);
+
+        assertEquals(new Sample(
+           "org_graylog2_plugin_streams_StreamRule:executionTime",
+           Arrays.asList("quantile", "id", "rule-type","stream-id", "stream-title", "index-set-id"),
+           Arrays.asList("0.5","58934a5e92493a6b7f384059","PRESENCE", "x", "foo", "42"),
+           1.0050000000000001E-6
+        ),s);
+
+    }
+
+    @Test
+    public void doTestMetricWithoutID() throws Exception {
+        when(streamRuleService.load(anyString())).thenReturn(streamRule);
+        when(streamRule.getStreamId()).thenReturn("x");
+        when(streamRule.getType()).thenReturn(StreamRuleType.PRESENCE);
+
+        when(streamService.load("x")).thenReturn(stream);
+        when(stream.getTitle()).thenReturn("foo");
+        when(stream.getIndexSetId()).thenReturn("42");
+
+        Sample s = sampleBuilder.createSample("jvm.threads.timed.waiting.count", "",emptyList(), emptyList(), 66.0);
+
+        assertEquals(new Sample(
+           "jvm_threads_timed_waiting_count",
+           emptyList(),
+           emptyList(),
+           66.0
+        ),s);
+    }
+
+    @Test
+    public void doTestNonStreamIDMetric() throws Exception {
+        Sample s = sampleBuilder.createSample("org.graylog2.inputs.extractors.RegexExtractor.regex.203bfc45-0acd-4a82-b4fd-c3710fdce62d.conditionHits", "",emptyList(), emptyList(),  1906140.0);
+
+        assertEquals(new Sample(
+           "org_graylog2_inputs_extractors_RegexExtractor_regex:conditionHits",
+           asList("id"),
+           asList("203bfc45-0acd-4a82-b4fd-c3710fdce62d"),
+           1906140.0
+        ),s);
+    }
+}

--- a/metrics-reporter-prometheus/src/test/java/org/graylog/plugins/metrics/prometheus/DropwizardSampleBuilderTest.java
+++ b/metrics-reporter-prometheus/src/test/java/org/graylog/plugins/metrics/prometheus/DropwizardSampleBuilderTest.java
@@ -27,6 +27,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Answers;
+import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
@@ -75,6 +76,26 @@ public class DropwizardSampleBuilderTest {
            2.0
         ),s);
     }
+
+    //
+    @Test
+    public void doTestStreamStreamRule() throws Exception {
+        when(streamRuleService.load(Matchers.eq("5d35b414bf1062c54c8c8680"))).thenReturn(streamRule);
+        when(streamRule.getType()).thenReturn(StreamRuleType.PRESENCE);
+
+        when(streamService.load(Matchers.eq("5d356589bf1062c54c8c37ee"))).thenReturn(stream);
+        when(stream.getTitle()).thenReturn("foo");
+
+        Sample s = sampleBuilder.createSample("org.graylog2.plugin.streams.Stream.5d356589bf1062c54c8c37ee.StreamRule.5d35b414bf1062c54c8c8680.executionTime", "", asList("quantile"), asList("0.5"), 1.0050000000000001E-6);
+
+        assertEquals(new Sample(
+           "org_graylog2_plugin_streams_Stream_StreamRule_executionTime",
+           Arrays.asList("quantile", "id", "stream_title", "stream_rule_id", "rule_type"),
+           Arrays.asList("0.5", "5d356589bf1062c54c8c37ee","foo","5d35b414bf1062c54c8c8680","PRESENCE"),
+           1.0050000000000001E-6
+        ),s);
+    }
+
 
     @Test
     public void doTestStreamRule() throws Exception {

--- a/metrics-reporter-prometheus/src/test/java/org/graylog/plugins/metrics/prometheus/DropwizardSampleBuilderTest.java
+++ b/metrics-reporter-prometheus/src/test/java/org/graylog/plugins/metrics/prometheus/DropwizardSampleBuilderTest.java
@@ -16,10 +16,7 @@
  */
 package org.graylog.plugins.metrics.prometheus;
 
-import com.google.common.primitives.Ints;
-import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.Collector.MetricFamilySamples.Sample;
-import io.prometheus.client.exporter.PushGateway;
 
 import org.graylog2.plugin.streams.Stream;
 import org.graylog2.plugin.streams.StreamRule;
@@ -34,18 +31,11 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
-import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import static java.util.Collections.emptyList;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.when;
 
 import static java.util.Arrays.*;
@@ -129,7 +119,7 @@ public class DropwizardSampleBuilderTest {
 
     @Test
     public void doTestNonStreamIDMetric() throws Exception {
-        Sample s = sampleBuilder.createSample("org.graylog2.inputs.extractors.RegexExtractor.regex.203bfc45-0acd-4a82-b4fd-c3710fdce62d.conditionHits", "",emptyList(), emptyList(),  1906140.0);
+        Sample s = sampleBuilder.createSample("org.graylog2.inputs.extractors.RegexExtractor.regex.203bfc45-0acd-4a82-b4fd-c3710fdce62d.conditionHits", "",emptyList(), emptyList(), 1906140.0);
 
         assertEquals(new Sample(
            "org_graylog2_inputs_extractors_RegexExtractor_regex_conditionHits",
@@ -137,5 +127,17 @@ public class DropwizardSampleBuilderTest {
            asList("203bfc45-0acd-4a82-b4fd-c3710fdce62d"),
            1906140.0
         ),s);
+    }
+
+    @Test
+    public void doTestPipelineRuleWithStage() throws Exception {
+        Sample s = sampleBuilder.createSample("org.graylog.plugins.pipelineprocessor.ast.Rule.5c1f6c332d44a501320636ae.5c1f6c492d44a501320636c7.0.not-matched", "",emptyList(), emptyList(), 0.0);
+
+        assertEquals(new Sample(
+            "org_graylog_plugins_pipelineprocessor_ast_Rule_not_matched",
+            asList("id", "pipeline-id", "stage"),
+            asList("5c1f6c332d44a501320636ae", "5c1f6c492d44a501320636c7", "0"),
+            0.0
+         ),s);
     }
 }

--- a/metrics-reporter-prometheus/src/test/java/org/graylog/plugins/metrics/prometheus/DropwizardSampleBuilderTest.java
+++ b/metrics-reporter-prometheus/src/test/java/org/graylog/plugins/metrics/prometheus/DropwizardSampleBuilderTest.java
@@ -79,7 +79,7 @@ public class DropwizardSampleBuilderTest {
         Sample s = sampleBuilder.createSample("org.graylog2.plugin.streams.Stream.58934a5e92493a6b7f383fea.incomingMessages.1-sec-rate", "", null, null, 2.0);
 
         assertEquals(new Sample(
-           "org_graylog2_plugin_streams_Stream:incomingMessages_1_sec_rate",
+           "org_graylog2_plugin_streams_Stream_incomingMessages_1_sec_rate",
            Arrays.asList("id", "stream-title", "index-set-id"),
            Arrays.asList("58934a5e92493a6b7f383fea","foo", "42"),
            2.0
@@ -99,7 +99,7 @@ public class DropwizardSampleBuilderTest {
         Sample s = sampleBuilder.createSample("org.graylog2.plugin.streams.StreamRule.58934a5e92493a6b7f384059.executionTime", "", asList("quantile"), asList("0.5"), 1.0050000000000001E-6);
 
         assertEquals(new Sample(
-           "org_graylog2_plugin_streams_StreamRule:executionTime",
+           "org_graylog2_plugin_streams_StreamRule_executionTime",
            Arrays.asList("quantile", "id", "rule-type","stream-id", "stream-title", "index-set-id"),
            Arrays.asList("0.5","58934a5e92493a6b7f384059","PRESENCE", "x", "foo", "42"),
            1.0050000000000001E-6
@@ -132,7 +132,7 @@ public class DropwizardSampleBuilderTest {
         Sample s = sampleBuilder.createSample("org.graylog2.inputs.extractors.RegexExtractor.regex.203bfc45-0acd-4a82-b4fd-c3710fdce62d.conditionHits", "",emptyList(), emptyList(),  1906140.0);
 
         assertEquals(new Sample(
-           "org_graylog2_inputs_extractors_RegexExtractor_regex:conditionHits",
+           "org_graylog2_inputs_extractors_RegexExtractor_regex_conditionHits",
            asList("id"),
            asList("203bfc45-0acd-4a82-b4fd-c3710fdce62d"),
            1906140.0

--- a/metrics-reporter-prometheus/src/test/java/org/graylog/plugins/metrics/prometheus/DropwizardSampleBuilderTest.java
+++ b/metrics-reporter-prometheus/src/test/java/org/graylog/plugins/metrics/prometheus/DropwizardSampleBuilderTest.java
@@ -140,4 +140,16 @@ public class DropwizardSampleBuilderTest {
             0.0
          ),s);
     }
+
+    @Test
+    public void doTestPipelineRuleWithoutStage() throws Exception {
+        Sample s = sampleBuilder.createSample("org.graylog.plugins.pipelineprocessor.ast.Rule.5c1f6c332d44a501320636ae.executed", "",emptyList(), emptyList(), 0.0);
+
+        assertEquals(new Sample(
+            "org_graylog_plugins_pipelineprocessor_ast_Rule_executed",
+            asList("id"),
+            asList("5c1f6c332d44a501320636ae"),
+            0.0
+         ),s);
+    }
 }

--- a/metrics-reporter-prometheus/src/test/java/org/graylog/plugins/metrics/prometheus/DropwizardSampleBuilderTest.java
+++ b/metrics-reporter-prometheus/src/test/java/org/graylog/plugins/metrics/prometheus/DropwizardSampleBuilderTest.java
@@ -70,7 +70,7 @@ public class DropwizardSampleBuilderTest {
 
         assertEquals(new Sample(
            "org_graylog2_plugin_streams_Stream_incomingMessages_1_sec_rate",
-           Arrays.asList("id", "stream-title", "index-set-id"),
+           Arrays.asList("id", "stream_title", "index_set_id"),
            Arrays.asList("58934a5e92493a6b7f383fea","foo", "42"),
            2.0
         ),s);
@@ -90,7 +90,7 @@ public class DropwizardSampleBuilderTest {
 
         assertEquals(new Sample(
            "org_graylog2_plugin_streams_StreamRule_executionTime",
-           Arrays.asList("quantile", "id", "rule-type","stream-id", "stream-title", "index-set-id"),
+           Arrays.asList("quantile", "id", "rule_type","stream_id", "stream_title", "index_set_id"),
            Arrays.asList("0.5","58934a5e92493a6b7f384059","PRESENCE", "x", "foo", "42"),
            1.0050000000000001E-6
         ),s);
@@ -135,7 +135,7 @@ public class DropwizardSampleBuilderTest {
 
         assertEquals(new Sample(
             "org_graylog_plugins_pipelineprocessor_ast_Rule_not_matched",
-            asList("id", "pipeline-id", "stage"),
+            asList("id", "pipeline_id", "stage"),
             asList("5c1f6c332d44a501320636ae", "5c1f6c492d44a501320636c7", "0"),
             0.0
          ),s);

--- a/metrics-reporter-prometheus/src/test/java/org/graylog/plugins/metrics/prometheus/PushGatewayPeriodicalTest.java
+++ b/metrics-reporter-prometheus/src/test/java/org/graylog/plugins/metrics/prometheus/PushGatewayPeriodicalTest.java
@@ -40,6 +40,7 @@ public class PushGatewayPeriodicalTest {
 
     private final MetricsPrometheusReporterConfiguration configuration = new MetricsPrometheusReporterConfiguration();
     private final CollectorRegistry collectorRegistry = new CollectorRegistry();
+
     @Mock
     private PushGateway pushGateway;
     private PushGatewayPeriodical periodical;
@@ -85,7 +86,6 @@ public class PushGatewayPeriodicalTest {
     @Test
     public void isDaemonIsTrue() throws Exception {
         assertTrue(periodical.isDaemon());
-
     }
 
     @Test

--- a/metrics-reporter-prometheus/src/test/java/org/graylog/plugins/metrics/prometheus/rest/MetricsResourceTest.java
+++ b/metrics-reporter-prometheus/src/test/java/org/graylog/plugins/metrics/prometheus/rest/MetricsResourceTest.java
@@ -24,20 +24,29 @@ import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.test.JerseyTest;
 import org.graylog.plugins.metrics.prometheus.MetricsPrometheusReporterModule;
 import org.graylog2.shared.bindings.GuiceInjectorHolder;
+import org.graylog2.streams.StreamRuleService;
+import org.graylog2.streams.StreamService;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.Response;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 public class MetricsResourceTest extends JerseyTest {
     public MetricsResourceTest() {
         final Module metricsModule = binder -> {
             final MetricRegistry registry = new MetricRegistry();
+            final StreamRuleService srs = mock(StreamRuleService.class);
+            final StreamService ss = mock(StreamService.class);
             final Counter counter = registry.counter("test.counter");
             counter.inc(42L);
+
+            binder.bind(StreamRuleService.class).toInstance(srs);
+            binder.bind(StreamService.class).toInstance(ss);
             binder.bind(MetricRegistry.class).toInstance(registry);
         };
         GuiceInjectorHolder.createInjector(ImmutableList.of(new MetricsPrometheusReporterModule(), metricsModule));


### PR DESCRIPTION
The current plugin version embeds ids in the metric names, which leads to a proliferation of metrics names and makes aggregations more difficult than necessary:

```
# HELP org_graylog2_plugin_streams_Stream_000000000000000000000001_incomingMessages_1_sec_rate Generated from Dropwizard metric import (metric=org.graylog2.plugin.streams.Stream.000000000000000000000001.incomingMessages.1-sec-rate, type=org.graylog2.periodical.ThroughputCalculator$2)
# TYPE org_graylog2_plugin_streams_Stream_000000000000000000000001_incomingMessages_1_sec_rate gauge
org_graylog2_plugin_streams_Stream_000000000000000000000001_incomingMessages_1_sec_rate 950.0
```

The updated version updates the prometheus clients version and introduces a custom sample builder to build better metrics names:

```
# HELP org_graylog2_plugin_streams_Stream_incomingMessages Generated from Dropwizard metric import (metric=org.graylog2.plugin.streams.Stream.000000000000000000000001.incomingMessages, type=com.codahale.metrics.Meter)
# TYPE org_graylog2_plugin_streams_Stream_incomingMessages_1_sec_rate gauge
org_graylog2_plugin_streams_Stream_incomingMessages{id="000000000000000000000001",stream-title="All messages",index-set-id="5d6638d23b3af5000fad234f",} 64784.0
```

For all metrics that contain an Id in the metric name, the Id is extracted to a label; other metric names are not modified.

For steams and stream rules some additional information is extracted and provided as labels:

* id for stream, (stream) rule, input, ...
* rule-type for (stream) rule
* stream-id for stream rule
* stream-title for stream and stream rule
* index-set-id for stream and stream rule

